### PR TITLE
16 create main content to menu screen

### DIFF
--- a/components/MenuSheet.tsx
+++ b/components/MenuSheet.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import {
+  ScrollView, StyleSheet, Text, View
+} from "react-native";
+import { BistroData } from "../data/bistroData";
+
+interface Props {
+  bistro?: BistroData;
+}
+
+export default function MenuSheet({ bistro }: Props) {
+  return (
+    <View style={styles.container}>
+    <ScrollView contentContainerStyle={styles.contentContainer}>
+      <View>
+        <Text style={[styles.font, styles.bistro]}>
+          {bistro?.title}
+        </Text>
+        <Text style={[styles.font, styles.timeAndPrice]}>
+          Serveras mellan:{" "}
+          {bistro?.lunchOfTheWeekDefault.monday?.lunchStart.toFixed(2)}{" "}
+          - {bistro?.lunchOfTheWeekDefault.monday?.lunchEnd.toFixed(2)}
+        </Text>
+        {bistro?.lunchOfTheWeekDefault.monday?.dishes.map(
+          (dish, index) => {
+            return (
+              <Text style={[styles.font, styles.course]} key={index}>
+                {dish}
+              </Text>
+            );
+          }
+        )}
+      </View>
+      <View>
+        <Text style={[styles.font, styles.timeAndPrice]}>
+          {bistro?.lunchOfTheWeekDefault.monday?.priceFrom}:-
+        </Text>
+      </View>
+    </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    justifyContent: "center",
+    marginTop: 50,
+    marginBottom: 50,
+  },
+  contentContainer: {
+    backgroundColor: "#fff",
+    width: 309,
+    minHeight: 300,
+    opacity: 0.95,
+    padding: 20,
+    justifyContent: "space-between",
+  },
+  font: {
+    color: "#000",
+    fontFamily: "Roboto",
+  },
+  bistro: {
+    fontWeight: "bold",
+    fontSize: 23,
+    paddingTop: 2,
+  },
+  timeAndPrice: {
+    fontSize: 18,
+    paddingTop: 15,
+    paddingBottom: 5,
+  },
+  course: {
+    fontSize: 12,
+    paddingTop: 5,
+    paddingBottom: 5,
+  },
+});

--- a/navigation/LinkingConfiguration.ts
+++ b/navigation/LinkingConfiguration.ts
@@ -10,25 +10,30 @@ import * as Linking from 'expo-linking';
 import { RootStackParamList } from '../types';
 
 const linking: LinkingOptions<RootStackParamList> = {
-  prefixes: [Linking.makeUrl('/')],
+  prefixes: [Linking.makeUrl("/")],
   config: {
     screens: {
       Root: {
         screens: {
           TabOne: {
             screens: {
-              TabOneScreen: 'one',
+              TabOneScreen: "one",
             },
           },
           TabTwo: {
             screens: {
-              TabTwoScreen: 'two',
+              TabTwoScreen: "two",
+            },
+          },
+          Menu: {
+            screens: {
+              MenuScreen: "menu",
             },
           },
         },
       },
-      Modal: 'modal',
-      NotFound: '*',
+      Modal: "modal",
+      NotFound: "*",
     },
   },
 };

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -12,6 +12,7 @@ import { ColorSchemeName, Pressable } from 'react-native';
 
 import Colors from '../constants/Colors';
 import useColorScheme from '../hooks/useColorScheme';
+import MenuScreen from '../screens/MenuScreen';
 import ModalScreen from '../screens/ModalScreen';
 import NotFoundScreen from '../screens/NotFoundScreen';
 import TabOneScreen from '../screens/TabOneScreen';
@@ -61,19 +62,21 @@ function BottomTabNavigator() {
       initialRouteName="TabOne"
       screenOptions={{
         tabBarActiveTintColor: Colors[colorScheme].tint,
-      }}>
+      }}
+    >
       <BottomTab.Screen
         name="TabOne"
         component={TabOneScreen}
-        options={({ navigation }: RootTabScreenProps<'TabOne'>) => ({
-          title: 'Tab One',
+        options={({ navigation }: RootTabScreenProps<"TabOne">) => ({
+          title: "Tab One",
           tabBarIcon: ({ color }) => <TabBarIcon name="code" color={color} />,
           headerRight: () => (
             <Pressable
-              onPress={() => navigation.navigate('Modal')}
+              onPress={() => navigation.navigate("Modal")}
               style={({ pressed }) => ({
                 opacity: pressed ? 0.5 : 1,
-              })}>
+              })}
+            >
               <FontAwesome
                 name="info-circle"
                 size={25}
@@ -88,7 +91,15 @@ function BottomTabNavigator() {
         name="TabTwo"
         component={TabTwoScreen}
         options={{
-          title: 'Tab Two',
+          title: "Tab Two",
+          tabBarIcon: ({ color }) => <TabBarIcon name="code" color={color} />,
+        }}
+      />
+      <BottomTab.Screen
+        name="Menu"
+        component={MenuScreen}
+        options={{
+          title: "Menu",
           tabBarIcon: ({ color }) => <TabBarIcon name="code" color={color} />,
         }}
       />

--- a/screens/MenuScreen.tsx
+++ b/screens/MenuScreen.tsx
@@ -1,0 +1,86 @@
+import * as React from "react";
+import { useContext } from "react";
+import { ImageBackground, ScrollView, StyleSheet } from "react-native";
+import { Text, View } from "../components/Themed";
+import { BistroContext } from "../contexts/BistroContext";
+import { RootTabScreenProps } from "../types";
+
+export default function MenuScreen( id: string, { navigation }: RootTabScreenProps<"Menu">) {
+  const { storedBistros } = useContext(BistroContext);
+  const selectedBistro = storedBistros.find((bistro) => bistro.id === "1"); //Hårdkodat (The Company), skrivs om när vi vet hur id kan skickas in som parameter
+
+  return (
+    <View style={styles.container}>
+      <ImageBackground
+        style={styles.background}
+        source={require("../images/sandwalls-plats.jpg")}
+      >
+        <ScrollView style={styles.menuSheet}>
+          <Text style={[styles.font, styles.bistro]}>
+            {selectedBistro?.title}
+          </Text>
+          <Text style={[styles.font, styles.timeAndPrice]}>
+            Serveras mellan:{" "}
+            {selectedBistro?.lunchOfTheWeekDefault.monday?.lunchStart.toFixed(2)}
+            {" "}-{" "}
+            {selectedBistro?.lunchOfTheWeekDefault.monday?.lunchEnd.toFixed(2)}
+          </Text>
+          {selectedBistro?.lunchOfTheWeekDefault.monday?.dishes.map(
+            (dish, index) => {
+              return (
+                <Text style={[styles.font, styles.course]} key={index}>
+                  {dish}
+                </Text>
+              );
+            }
+          )}
+          <Text style={[styles.font, styles.timeAndPrice]}>
+            {selectedBistro?.lunchOfTheWeekDefault.monday?.priceFrom}:-
+          </Text>
+        </ScrollView>
+      </ImageBackground>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  background: {
+    flex: 1,
+    resizeMode: "cover",
+    width: "100%",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  menuSheet: {
+    backgroundColor: "#fff",
+    width: 309,
+    maxHeight: 427,
+    color: "#000",
+    opacity: 0.95,
+    padding: 20,
+  },
+  font: {
+    color: "#000",
+    fontFamily: "Roboto",
+  },
+  bistro: {
+    fontWeight: "bold",
+    fontSize: 23,
+    paddingTop: 2,
+  },
+  timeAndPrice: {
+    fontSize: 18,
+    paddingTop: 15,
+    paddingBottom: 5,
+  },
+  course: {
+    fontSize: 12,
+    paddingTop: 5,
+    paddingBottom: 5,
+  },
+});

--- a/screens/MenuScreen.tsx
+++ b/screens/MenuScreen.tsx
@@ -1,43 +1,23 @@
 import * as React from "react";
 import { useContext } from "react";
-import { ImageBackground, ScrollView, StyleSheet } from "react-native";
-import { Text, View } from "../components/Themed";
+import { ImageBackground, StyleSheet } from "react-native";
+import MenuSheet from "../components/MenuSheet";
+import { View } from "../components/Themed";
 import { BistroContext } from "../contexts/BistroContext";
+import { BistroData } from "../data/bistroData";
 import { RootTabScreenProps } from "../types";
 
-export default function MenuScreen( id: string, { navigation }: RootTabScreenProps<"Menu">) {
-  const { storedBistros } = useContext(BistroContext);
-  const selectedBistro = storedBistros.find((bistro) => bistro.id === "1"); //Hårdkodat (The Company), skrivs om när vi vet hur id kan skickas in som parameter
-
+export default function MenuScreen( bistro: BistroData, { navigation }: RootTabScreenProps<"Menu">) {
+    const id = '1';
+    const { storedBistros } = useContext(BistroContext);
+    const selectedBistro = storedBistros.find((bistro) => bistro.id === id);
   return (
     <View style={styles.container}>
       <ImageBackground
         style={styles.background}
         source={require("../images/sandwalls-plats.jpg")}
       >
-        <ScrollView style={styles.menuSheet}>
-          <Text style={[styles.font, styles.bistro]}>
-            {selectedBistro?.title}
-          </Text>
-          <Text style={[styles.font, styles.timeAndPrice]}>
-            Serveras mellan:{" "}
-            {selectedBistro?.lunchOfTheWeekDefault.monday?.lunchStart.toFixed(2)}
-            {" "}-{" "}
-            {selectedBistro?.lunchOfTheWeekDefault.monday?.lunchEnd.toFixed(2)}
-          </Text>
-          {selectedBistro?.lunchOfTheWeekDefault.monday?.dishes.map(
-            (dish, index) => {
-              return (
-                <Text style={[styles.font, styles.course]} key={index}>
-                  {dish}
-                </Text>
-              );
-            }
-          )}
-          <Text style={[styles.font, styles.timeAndPrice]}>
-            {selectedBistro?.lunchOfTheWeekDefault.monday?.priceFrom}:-
-          </Text>
-        </ScrollView>
+        <MenuSheet bistro={selectedBistro}/>
       </ImageBackground>
     </View>
   );
@@ -55,32 +35,5 @@ const styles = StyleSheet.create({
     width: "100%",
     alignItems: "center",
     justifyContent: "center",
-  },
-  menuSheet: {
-    backgroundColor: "#fff",
-    width: 309,
-    maxHeight: 427,
-    color: "#000",
-    opacity: 0.95,
-    padding: 20,
-  },
-  font: {
-    color: "#000",
-    fontFamily: "Roboto",
-  },
-  bistro: {
-    fontWeight: "bold",
-    fontSize: 23,
-    paddingTop: 2,
-  },
-  timeAndPrice: {
-    fontSize: 18,
-    paddingTop: 15,
-    paddingBottom: 5,
-  },
-  course: {
-    fontSize: 12,
-    paddingTop: 5,
-    paddingBottom: 5,
-  },
+  }
 });

--- a/types.tsx
+++ b/types.tsx
@@ -27,6 +27,7 @@ export type RootStackScreenProps<Screen extends keyof RootStackParamList> = Nati
 export type RootTabParamList = {
   TabOne: undefined;
   TabTwo: undefined;
+  Menu: undefined;
 };
 
 export type RootTabScreenProps<Screen extends keyof RootTabParamList> = CompositeScreenProps<


### PR DESCRIPTION
close #16 

Every Text-field has the fontFamily "Roboto". According to design the time and price textfields have "Tomorrow" as fontFamily. If another fontFamily is required, changes can be made easily afterwards.

The MenuSheet is a ScrollView, responsive depending on the fill of the text, and has a max height of 427. This is because it shouldn't wrap the entire height of the screen.

The background needs to be adjusted when we decide how it is supposed to look on both loading screen and this screen.

The restaurant info is fetched by hardcoded id-value (1) and day-value (monday). It should in further development get id as a parameter and in some way get knowledge about selected day as well.

ALSO:
Added a new tab for menu, to be able to see it in the app before navigation is completed. 

![menu](https://user-images.githubusercontent.com/71378960/134956768-83003330-624c-48ce-9c96-13defcf6a659.png)

