### PR TITLE
12 create map to mapscreen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
         "react-native-elements": "^3.4.2",
         "react-native-gesture-handler": "~1.10.2",
+        "react-native-maps": "0.28.0",
         "react-native-pager-view": "5.0.12",
         "react-native-paper": "^4.9.2",
         "react-native-reanimated": "~2.2.0",
@@ -31,7 +32,7 @@
         "react-native-screens": "~3.4.0",
         "react-native-tab-view": "^3.1.1",
         "react-native-uuid": "^2.0.1",
-        "react-native-web": "~0.13.12"
+        "react-native-web": "^0.11.7"
       },
       "devDependencies": {
         "@babel/core": "^7.9.0",
@@ -4108,6 +4109,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.8",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -5873,6 +5879,11 @@
       "version": "1.10.7",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
       "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+    },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
     },
     "node_modules/debug": {
       "version": "4.3.2",
@@ -14281,6 +14292,19 @@
         "ua-parser-js": "^0.7.18"
       }
     },
+    "node_modules/react-native-maps": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-0.28.0.tgz",
+      "integrity": "sha512-F+k5ZT9hhl+iXR1H+5ZcoHOEB5lPu9gCIwtA4lI/LoI9nfa9xFvr1vMiLIv44jzeGNzbE3+/R81IpcNDMJ5uDg==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.7"
+      },
+      "peerDependencies": {
+        "react": ">= 16.0 || < 17.0",
+        "react-native": ">= 0.51",
+        "react-native-web": "^0.11"
+      }
+    },
     "node_modules/react-native-pager-view": {
       "version": "5.0.12",
       "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-5.0.12.tgz",
@@ -14521,16 +14545,17 @@
       }
     },
     "node_modules/react-native-web": {
-      "version": "0.13.18",
-      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.13.18.tgz",
-      "integrity": "sha512-WR/0ECAmwLQ2+2cL2Ur+0/swXFAtcSM0URoADJmG6D4MnY+wGc91JO8LoOTlgY0USBOY+qG/beRrjFa+RAuOiA==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.11.7.tgz",
+      "integrity": "sha512-w1KAxX2FYLS2GAi3w3BnEZg/IUu7FdgHnLmFKHplRnHMV3u1OPB2EVA7ndNdfu7ds4Rn2OZjSXoNh6F61g3gkA==",
       "dependencies": {
         "array-find-index": "^1.0.2",
         "create-react-class": "^15.6.2",
+        "debounce": "^1.2.0",
         "deep-assign": "^3.0.0",
         "fbjs": "^1.0.0",
-        "hyphenate-style-name": "^1.0.3",
-        "inline-style-prefixer": "^5.1.0",
+        "hyphenate-style-name": "^1.0.2",
+        "inline-style-prefixer": "^5.0.3",
         "normalize-css-color": "^1.0.2",
         "prop-types": "^15.6.0",
         "react-timer-mixin": "^0.13.4"
@@ -20797,6 +20822,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/geojson": {
+      "version": "7946.0.8",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -22232,6 +22262,11 @@
       "version": "1.10.7",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
       "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+    },
+    "debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
     },
     "debug": {
       "version": "4.3.2",
@@ -29266,6 +29301,14 @@
         }
       }
     },
+    "react-native-maps": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-0.28.0.tgz",
+      "integrity": "sha512-F+k5ZT9hhl+iXR1H+5ZcoHOEB5lPu9gCIwtA4lI/LoI9nfa9xFvr1vMiLIv44jzeGNzbE3+/R81IpcNDMJ5uDg==",
+      "requires": {
+        "@types/geojson": "^7946.0.7"
+      }
+    },
     "react-native-pager-view": {
       "version": "5.0.12",
       "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-5.0.12.tgz",
@@ -29448,16 +29491,17 @@
       }
     },
     "react-native-web": {
-      "version": "0.13.18",
-      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.13.18.tgz",
-      "integrity": "sha512-WR/0ECAmwLQ2+2cL2Ur+0/swXFAtcSM0URoADJmG6D4MnY+wGc91JO8LoOTlgY0USBOY+qG/beRrjFa+RAuOiA==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.11.7.tgz",
+      "integrity": "sha512-w1KAxX2FYLS2GAi3w3BnEZg/IUu7FdgHnLmFKHplRnHMV3u1OPB2EVA7ndNdfu7ds4Rn2OZjSXoNh6F61g3gkA==",
       "requires": {
         "array-find-index": "^1.0.2",
         "create-react-class": "^15.6.2",
+        "debounce": "^1.2.0",
         "deep-assign": "^3.0.0",
         "fbjs": "^1.0.0",
-        "hyphenate-style-name": "^1.0.3",
-        "inline-style-prefixer": "^5.1.0",
+        "hyphenate-style-name": "^1.0.2",
+        "inline-style-prefixer": "^5.0.3",
         "normalize-css-color": "^1.0.2",
         "prop-types": "^15.6.0",
         "react-timer-mixin": "^0.13.4"

--- a/package.json
+++ b/package.json
@@ -31,14 +31,15 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
     "react-native-elements": "^3.4.2",
     "react-native-gesture-handler": "~1.10.2",
+    "react-native-maps": "0.28.0",
+    "react-native-pager-view": "5.0.12",
     "react-native-paper": "^4.9.2",
     "react-native-reanimated": "~2.2.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.4.0",
     "react-native-tab-view": "^3.1.1",
     "react-native-uuid": "^2.0.1",
-    "react-native-web": "~0.13.12",
-    "react-native-pager-view": "5.0.12"
+    "react-native-web": "^0.11.7"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/screens/TabTwoScreen.tsx
+++ b/screens/TabTwoScreen.tsx
@@ -1,32 +1,19 @@
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
-
-import EditScreenInfo from '../components/EditScreenInfo';
-import { Text, View } from '../components/Themed';
+import { Dimensions, StyleSheet } from 'react-native';
+import MapView from 'react-native-maps';
+import { View } from '../components/Themed';
 
 export default function TabTwoScreen() {
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Tab Two</Text>
-      <View style={styles.separator} lightColor="#eee" darkColor="rgba(255,255,255,0.1)" />
-      <EditScreenInfo path="/screens/TabTwoScreen.tsx" />
+    <View>
+      <MapView style={styles.map} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: 'bold',
-  },
-  separator: {
-    marginVertical: 30,
-    height: 1,
-    width: '80%',
+  map: {
+    width: Dimensions.get('window').width,
+    height: Dimensions.get('window').height,
   },
 });

--- a/screens/TabTwoScreen.tsx
+++ b/screens/TabTwoScreen.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Dimensions, StyleSheet } from 'react-native';
-import MapView, { Marker } from 'react-native-maps';
+import MapView from 'react-native-maps';
 import { View } from '../components/Themed';
 
 export default function TabTwoScreen() {

--- a/screens/TabTwoScreen.tsx
+++ b/screens/TabTwoScreen.tsx
@@ -1,12 +1,18 @@
 import * as React from 'react';
 import { Dimensions, StyleSheet } from 'react-native';
-import MapView from 'react-native-maps';
+import MapView, { Marker } from 'react-native-maps';
 import { View } from '../components/Themed';
 
 export default function TabTwoScreen() {
   return (
     <View>
-      <MapView style={styles.map} />
+      <MapView style={styles.map} 
+      initialRegion={{
+        latitude: 57.7206788,
+        longitude: 12.9414395,
+        latitudeDelta: 0.0022,
+        longitudeDelta: 0.0021,
+      }}/>
     </View>
   );
 }


### PR DESCRIPTION
Run npm install before starting up the project.

Added react-native-map to the project to implement <MapView>. For now borås city coordinates is in the focus when toggling to "kartor". For further implementation see if we gonna ad location-tracking on the unit to automaticly load the units "here am I" marker. 

Added:
 width: Dimensions.get('window').width,
 height: Dimensions.get('window').height,

to make the map stretch over the screen.

This implementation should further on be in MapScreen.tsx 

Close #12 