### PR TITLE
18 create menucontent box to menuscreen

### DIFF
--- a/components/MenuInfoBox.tsx
+++ b/components/MenuInfoBox.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export default function MenuInfoBox({ bistro }: Props) {
-  const map = () => console.log("Navigera till kartan"); //TODO: Behöver kunna navigera till kartan, istället för logg.
+  const map = () => console.log("Navigera till kartan"); //Radera när navigationen fungerar
   return (
     <View style={styles.container}>
       <Card style={styles.box}>
@@ -22,8 +22,10 @@ export default function MenuInfoBox({ bistro }: Props) {
             color="#fff"
             style={styles.icon}
           />
+          {/* TODO: Behöver kunna navigera till kartan, istället för logg. */}
           <TouchableOpacity onPress={map}>
             <Paragraph style={styles.distanceContainer}>
+              {/* TODO: Behöver kunna hämta antalet minuter och avstånd från kartan */}
               <Paragraph style={[styles.text, styles.time]}>15min </Paragraph>
               <Paragraph style={styles.text}>(2,2km)</Paragraph>
             </Paragraph>
@@ -34,10 +36,14 @@ export default function MenuInfoBox({ bistro }: Props) {
             {bistro?.address.streetAddress}, {bistro?.address.zipCode}{" "}
             {bistro?.address.city}
           </Paragraph>
-          <Paragraph onPress={() => PhoneDialer({bistro})} style={styles.text}>
+          <Paragraph
+            onPress={() => PhoneDialer({ bistro })}
+            style={styles.text}
+          >
             {bistro?.address.phone}
           </Paragraph>
-          <Paragraph style={styles.text}>Rating?</Paragraph>
+          {/* TODO: Implementera rating, om vi vill ha det? */}
+          <Paragraph style={styles.text}>Rating</Paragraph>
         </Card.Content>
       </Card>
     </View>

--- a/components/MenuInfoBox.tsx
+++ b/components/MenuInfoBox.tsx
@@ -1,0 +1,69 @@
+import { FontAwesome } from "@expo/vector-icons";
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { TouchableOpacity } from "react-native-gesture-handler";
+import { Card, Paragraph } from "react-native-paper";
+import { BistroData } from "../data/bistroData";
+import { PhoneDialer } from "./PhoneDialer";
+
+interface Props {
+  bistro?: BistroData;
+}
+
+export default function MenuInfoBox({ bistro }: Props) {
+  const map = () => console.log("Navigera till kartan"); //TODO: Behöver kunna navigera till kartan, istället för logg.
+  return (
+    <View style={styles.container}>
+      <Card style={styles.box}>
+        <Card.Actions>
+          <FontAwesome
+            name="map-marker"
+            size={30}
+            color="#fff"
+            style={styles.icon}
+          />
+          <TouchableOpacity onPress={map}>
+            <Paragraph style={styles.distanceContainer}>
+              <Paragraph style={[styles.text, styles.time]}>15min </Paragraph>
+              <Paragraph style={styles.text}>(2,2km)</Paragraph>
+            </Paragraph>
+          </TouchableOpacity>
+        </Card.Actions>
+        <Card.Content>
+          <Paragraph style={styles.text}>
+            {bistro?.address.streetAddress}, {bistro?.address.zipCode}{" "}
+            {bistro?.address.city}
+          </Paragraph>
+          <Paragraph onPress={() => PhoneDialer({bistro})} style={styles.text}>
+            {bistro?.address.phone}
+          </Paragraph>
+          <Paragraph style={styles.text}>Rating?</Paragraph>
+        </Card.Content>
+      </Card>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+      flex:1,
+    justifyContent: "flex-end",
+  },
+  box: {
+    borderRadius: 0,
+    backgroundColor: "#000000c0",
+    paddingTop: 8,
+  },
+  text: {
+    color: "#fff",
+  },
+  distanceContainer: {
+    paddingLeft: 15,
+  },
+  time: {
+    fontWeight: "bold",
+  },
+  icon: {
+    paddingLeft: 9,
+  },
+});

--- a/components/MenuInfoBox.tsx
+++ b/components/MenuInfoBox.tsx
@@ -16,19 +16,19 @@ export default function MenuInfoBox({ bistro }: Props) {
     <View style={styles.container}>
       <Card style={styles.box}>
         <Card.Actions>
-          <FontAwesome
-            name="map-marker"
-            size={30}
-            color="#fff"
-            style={styles.icon}
-          />
           {/* TODO: Behöver kunna navigera till kartan, istället för logg. */}
           <TouchableOpacity onPress={map}>
-            <Paragraph style={styles.distanceContainer}>
+            <View style={styles.distanceContainer}>
+              <FontAwesome
+                name="map-marker"
+                size={30}
+                color="#fff"
+                style={styles.icon}
+              />
               {/* TODO: Behöver kunna hämta antalet minuter och avstånd från kartan */}
               <Paragraph style={[styles.text, styles.time]}>15min </Paragraph>
               <Paragraph style={styles.text}>(2,2km)</Paragraph>
-            </Paragraph>
+            </View>
           </TouchableOpacity>
         </Card.Actions>
         <Card.Content>
@@ -36,14 +36,11 @@ export default function MenuInfoBox({ bistro }: Props) {
             {bistro?.address.streetAddress}, {bistro?.address.zipCode}{" "}
             {bistro?.address.city}
           </Paragraph>
-          <Paragraph
-            onPress={() => PhoneDialer({ bistro })}
-            style={styles.text}
-          >
-            {bistro?.address.phone}
-          </Paragraph>
-          {/* TODO: Implementera rating, om vi vill ha det? */}
-          <Paragraph style={styles.text}>Rating</Paragraph>
+          <TouchableOpacity onPress={() => PhoneDialer({ bistro })}>
+            <Paragraph style={[styles.text, styles.phone]}>
+              {bistro?.address.phone}
+            </Paragraph>
+          </TouchableOpacity>
         </Card.Content>
       </Card>
     </View>
@@ -52,7 +49,7 @@ export default function MenuInfoBox({ bistro }: Props) {
 
 const styles = StyleSheet.create({
   container: {
-      flex:1,
+    flex: 1,
     justifyContent: "flex-end",
   },
   box: {
@@ -64,12 +61,18 @@ const styles = StyleSheet.create({
     color: "#fff",
   },
   distanceContainer: {
-    paddingLeft: 15,
+    paddingLeft: 9,
+    paddingTop: 8,
+    flexDirection: "row",
+    alignItems: "center",
   },
   time: {
     fontWeight: "bold",
   },
   icon: {
-    paddingLeft: 9,
+    paddingRight: 9,
+  },
+  phone: {
+    textDecorationLine: "underline",
   },
 });

--- a/components/MenuSheet.tsx
+++ b/components/MenuSheet.tsx
@@ -44,7 +44,7 @@ const styles = StyleSheet.create({
   },
   contentContainer: {
     backgroundColor: "#fff",
-    width: 260,
+    width: 320,
     opacity: 0.95,
     padding: 20,
     justifyContent: "space-between",

--- a/components/MenuSheet.tsx
+++ b/components/MenuSheet.tsx
@@ -1,7 +1,5 @@
 import React from "react";
-import {
-  ScrollView, StyleSheet, Text, View
-} from "react-native";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
 import { BistroData } from "../data/bistroData";
 
 interface Props {
@@ -11,47 +9,42 @@ interface Props {
 export default function MenuSheet({ bistro }: Props) {
   return (
     <View style={styles.container}>
-    <ScrollView contentContainerStyle={styles.contentContainer}>
-      <View>
-        <Text style={[styles.font, styles.bistro]}>
-          {bistro?.title}
-        </Text>
-        <Text style={[styles.font, styles.timeAndPrice]}>
-          Serveras mellan:{" "}
-          {bistro?.lunchOfTheWeekDefault.monday?.lunchStart.toFixed(2)}{" "}
-          - {bistro?.lunchOfTheWeekDefault.monday?.lunchEnd.toFixed(2)}
-        </Text>
-        {bistro?.lunchOfTheWeekDefault.monday?.dishes.map(
-          (dish, index) => {
+      <ScrollView contentContainerStyle={styles.contentContainer}>
+        <View>
+          <Text style={[styles.font, styles.bistro]}>{bistro?.title}</Text>
+          <Text style={[styles.font, styles.timeAndPrice]}>
+            Serveras mellan:{" "}
+            {bistro?.lunchOfTheWeekDefault.monday?.lunchStart.toFixed(2)} -{" "}
+            {bistro?.lunchOfTheWeekDefault.monday?.lunchEnd.toFixed(2)}
+          </Text>
+          {bistro?.lunchOfTheWeekDefault.monday?.dishes.map((dish, index) => {
             return (
               <Text style={[styles.font, styles.course]} key={index}>
                 {dish}
               </Text>
             );
-          }
-        )}
-      </View>
-      <View>
-        <Text style={[styles.font, styles.timeAndPrice]}>
-          {bistro?.lunchOfTheWeekDefault.monday?.priceFrom}:-
-        </Text>
-      </View>
-    </ScrollView>
+          })}
+        </View>
+        <View>
+          <Text style={[styles.font, styles.timeAndPrice]}>
+            Från {bistro?.lunchOfTheWeekDefault.monday?.priceFrom}:-
+          </Text>
+        </View>
+      </ScrollView>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
+    flex: 2,
     alignItems: "center",
     justifyContent: "center",
     marginTop: 50,
-    marginBottom: 50,
   },
   contentContainer: {
     backgroundColor: "#fff",
-    width: 309,
-    minHeight: 300,
+    width: 260,
     opacity: 0.95,
     padding: 20,
     justifyContent: "space-between",
@@ -66,12 +59,12 @@ const styles = StyleSheet.create({
     paddingTop: 2,
   },
   timeAndPrice: {
-    fontSize: 18,
+    fontSize: 16,
     paddingTop: 15,
     paddingBottom: 5,
   },
   course: {
-    fontSize: 12,
+    fontSize: 11,
     paddingTop: 5,
     paddingBottom: 5,
   },

--- a/components/PhoneDialer.tsx
+++ b/components/PhoneDialer.tsx
@@ -18,6 +18,4 @@ function PhoneDialer({ bistro }: Props) {
   Linking.openURL(phoneNumber);
 }
 
-export {
-    PhoneDialer
-}
+export { PhoneDialer };

--- a/components/PhoneDialer.tsx
+++ b/components/PhoneDialer.tsx
@@ -1,0 +1,23 @@
+import { Linking, Platform } from "react-native";
+import { BistroData } from "../data/bistroData";
+
+interface Props {
+  bistro?: BistroData;
+}
+
+function PhoneDialer({ bistro }: Props) {
+  let phoneNumber = "";
+  const bistroPhoneNumber = bistro?.address.phone.toString();
+
+  if (Platform.OS === "android") {
+    phoneNumber = `tel:${bistroPhoneNumber}`;
+  } else {
+    phoneNumber = `telprompt:${bistroPhoneNumber}`;
+  }
+
+  Linking.openURL(phoneNumber);
+}
+
+export {
+    PhoneDialer
+}

--- a/screens/MenuScreen.tsx
+++ b/screens/MenuScreen.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useContext } from "react";
 import { ImageBackground, StyleSheet } from "react-native";
+import MenuInfoBox from "../components/MenuInfoBox";
 import MenuSheet from "../components/MenuSheet";
 import { View } from "../components/Themed";
 import { BistroContext } from "../contexts/BistroContext";
@@ -15,9 +16,10 @@ export default function MenuScreen( bistro: BistroData, { navigation }: RootTabS
     <View style={styles.container}>
       <ImageBackground
         style={styles.background}
-        source={require("../images/sandwalls-plats.jpg")}
+        source={require("../images/sandwalls-plats-blur.png")}
       >
         <MenuSheet bistro={selectedBistro}/>
+        <MenuInfoBox bistro={selectedBistro}/>
       </ImageBackground>
     </View>
   );
@@ -26,14 +28,10 @@ export default function MenuScreen( bistro: BistroData, { navigation }: RootTabS
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
   },
   background: {
     flex: 1,
     resizeMode: "cover",
     width: "100%",
-    alignItems: "center",
-    justifyContent: "center",
   }
 });

--- a/screens/MenuScreen.tsx
+++ b/screens/MenuScreen.tsx
@@ -16,7 +16,7 @@ export default function MenuScreen( bistro: BistroData, { navigation }: RootTabS
     <View style={styles.container}>
       <ImageBackground
         style={styles.background}
-        source={require("../images/sandwalls-plats-blur.png")}
+        source={require("../images/sandwalls-plats.jpg")}
       >
         <MenuSheet bistro={selectedBistro}/>
         <MenuInfoBox bistro={selectedBistro}/>


### PR DESCRIPTION
close #18 

MenuScreen is now displaying components MenuSheet and MenuInfoBox.

When pressing on phone number user will have to choose app to use for phone call. Works perfectly in android (Samsung S7). Haven't tried feature on iOS. 

Hardcoded parts that needs to be altered when navigation is completed:
- Get distance and time it takes to get to the restaurant. 
- Navigation to map when pressing on distance-field in MenuInfoBox.

Styling issue: Can't seem to be able to get the design on MenuSheet right. Please, can someone else have a try at it because this part needs some love, and I have tried to give it (but failed haha).

![menu4](https://user-images.githubusercontent.com/71378960/135281907-6d155507-2f0f-4ebd-847d-ca0fde24ede9.png)
