### PR TITLE
created like button

### DIFF
--- a/components/BistroCard.tsx
+++ b/components/BistroCard.tsx
@@ -3,6 +3,7 @@ import { ImageBackground, StyleSheet, View } from "react-native";
 import { TouchableOpacity } from "react-native-gesture-handler";
 import { Card, Title, Paragraph } from "react-native-paper";
 import { BistroData } from "../data/bistroData";
+import LikeButton from "./LikeButton";
 
 interface Props {
   bistro: BistroData;
@@ -58,6 +59,9 @@ const BistroCard = ({ bistro, weekday }: Props) => {
   return (
     <View style={styles.container}>
       <ImageBackground source={image} resizeMode="cover" style={styles.image}>
+        <View style={styles.likeButton}>
+      <LikeButton />
+      </View>
         <Card style={styles.box}>
           <Card.Actions>
             <TouchableOpacity onPress={onPress} onLongPress={onLongPress}>
@@ -88,6 +92,10 @@ const styles = StyleSheet.create({
   image: {
     flex: 1,
     justifyContent: "flex-end",
+  },
+  likeButton: {
+    flex: 1,
+    alignItems: "flex-end",
   },
   box: {
     borderRadius: 0,

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { IconButton } from "react-native-paper";
+
+const LikeButton = () => {
+  return (
+    <IconButton
+      icon="heart-outline"
+      color={"#F8607E"}
+      size={27}
+      //TODO: Toggle implementation for liking and unliking (icon-property should be "heart" when liked). 
+      //Store choice in state (in Bistrocontext?)
+      //by using likedBistro property for bistro object
+      onPress={() => console.log("Gillade!")}
+    />
+  );
+};
+
+export default LikeButton;


### PR DESCRIPTION
close #9 

Default liking button created with React native paper:
https://callstack.github.io/react-native-paper/icon-button.html

Added to bistroCard component for display, but implementation of toggle function for liking and unliking will be created in another issue. When liking, the icon will be filled (have property "icon="heart" instead of "heart-outline").

![heartbtn](https://user-images.githubusercontent.com/71378960/135447314-f34c04b7-7232-4a99-9a5c-bf58b61c10b7.png)
