### PR TITLE
10 create tags for bistro card

### DIFF
--- a/components/BistroCard.tsx
+++ b/components/BistroCard.tsx
@@ -9,6 +9,7 @@ import {
 import { TouchableOpacity } from "react-native-gesture-handler";
 import { Card, Title, Paragraph } from "react-native-paper";
 import { BistroData } from "../data/bistroData";
+import OfferTag from "./OfferTag";
 import LikeButton from "./LikeButton";
 
 interface Props {
@@ -67,8 +68,21 @@ const BistroCard = ({ bistro, weekday }: Props) => {
   return (
     <View style={styles.container}>
       <ImageBackground source={image} resizeMode="cover" style={styles.image}>
-        <View style={styles.likeButton}>
-          <LikeButton bistro={bistro} />
+        <View style={styles.tagsAndLikeContainer}>
+          <View style={styles.tags}>
+            {bistro.lunchOfTheWeekDefault.tags.coffeeIncluded ? (
+              <OfferTag infoText="Kaffe ingår" />
+            ) : null}
+            {bistro.lunchOfTheWeekDefault.tags.saladBuffet ? (
+              <OfferTag infoText="Salladsbuffé" />
+            ) : null}
+            {bistro.lunchOfTheWeekDefault.tags.outdoorSeating ? (
+              <OfferTag infoText="Uteservering" />
+            ) : null}
+          </View>
+          <View style={styles.likeButton}>
+            <LikeButton bistro={bistro} />
+          </View>
         </View>
         <Card style={styles.box}>
           <Card.Actions>
@@ -101,9 +115,18 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "flex-end",
   },
+  tagsAndLikeContainer: {
+    flex: 1,
+    flexDirection: "row",
+  },
   likeButton: {
     flex: 1,
     alignItems: "flex-end",
+  },
+  tags: {
+    flex: 1,
+    alignItems: "flex-start",
+    marginTop: 20,
   },
   box: {
     borderRadius: 0,

--- a/components/BistroCard.tsx
+++ b/components/BistroCard.tsx
@@ -71,13 +71,13 @@ const BistroCard = ({ bistro, weekday }: Props) => {
         <View style={styles.tagsAndLikeContainer}>
           <View style={styles.tags}>
             {bistro.lunchOfTheWeekDefault.tags.coffeeIncluded ? (
-              <OfferTag infoText="Kaffe ingår" />
+              <OfferTag displayText="Kaffe ingår" />
             ) : null}
             {bistro.lunchOfTheWeekDefault.tags.saladBuffet ? (
-              <OfferTag infoText="Salladsbuffé" />
+              <OfferTag displayText="Salladsbuffé" />
             ) : null}
             {bistro.lunchOfTheWeekDefault.tags.outdoorSeating ? (
-              <OfferTag infoText="Uteservering" />
+              <OfferTag displayText="Uteservering" />
             ) : null}
           </View>
           <View style={styles.likeButton}>

--- a/components/OfferTag.tsx
+++ b/components/OfferTag.tsx
@@ -3,13 +3,13 @@ import { Surface, Text } from "react-native-paper";
 import { StyleSheet } from "react-native";
 
 interface Props {
-  infoText: string;
+  displayText: string;
 }
 
-const OfferTag = ({ infoText }: Props) => {
+const OfferTag = ({ displayText }: Props) => {
   return (
     <Surface style={styles.tag}>
-      <Text style={styles.infoText}>{infoText}</Text>
+      <Text style={styles.displayText}>{displayText}</Text>
     </Surface>
   );
 };
@@ -29,7 +29,7 @@ const styles = StyleSheet.create({
     borderBottomEndRadius: 2,
     borderTopEndRadius: 2,
   },
-  infoText: {
+  displayText: {
     color: "#fff",
   },
 });

--- a/components/OfferTag.tsx
+++ b/components/OfferTag.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { Surface, Text } from "react-native-paper";
+import { StyleSheet } from "react-native";
+
+interface Props {
+  infoText: string;
+}
+
+const OfferTag = ({ infoText }: Props) => {
+  return (
+    <Surface style={styles.tag}>
+      <Text style={styles.infoText}>{infoText}</Text>
+    </Surface>
+  );
+};
+
+export default OfferTag;
+
+const styles = StyleSheet.create({
+  tag: {
+    marginBottom: 5,
+    padding: 6,
+    paddingLeft: 8,
+    backgroundColor: "#723A45",
+    maxWidth: 120,
+    alignItems: "center",
+    justifyContent: "center",
+    elevation: 6,
+    borderBottomEndRadius: 2,
+    borderTopEndRadius: 2,
+  },
+  infoText: {
+    color: "#fff",
+  },
+});


### PR DESCRIPTION
close #10 

Created OfferTag - component which takes in a string infoText-prop that describes the type of offer. OfferTag does not know anything about the bistros so it can be reused in other components/screens if neccessary.

BistroCard is rendering tags depending on booleans set for selected bistro. If the boolean is false, no tag will appear. If boolean is true the tag will get a string set that matches the boolean, ex. "Uteservering". The string is sent to OfferTag as a prop, as explained above.

For OfferTag I have used [Surface](https://callstack.github.io/react-native-paper/surface.html) from React Native Paper to also get a nice background shadow effect. It is not very visible, but gives a subtle depth.

*Alternations from original design:*
- The tag has a small border-radius to give it a smoother look
- The margin between the tags are a bit tighter, I thought it looked better that way. 

![tags](https://user-images.githubusercontent.com/71378960/135844189-e11896b6-afe3-46b0-aa51-6ce89db14094.png)
