### PR TITLE
removed ? from bistro in Props

### DIFF
--- a/components/PhoneDialer.tsx
+++ b/components/PhoneDialer.tsx
@@ -2,7 +2,7 @@ import { Linking, Platform } from "react-native";
 import { BistroData } from "../data/bistroData";
 
 interface Props {
-  bistro?: BistroData;
+  bistro: BistroData;
 }
 
 function PhoneDialer({ bistro }: Props) {


### PR DESCRIPTION
close #48 

Bistro is not an optional parameter in PhoneDialer anymore. Were optional before because of earlier structure in MenuScreen. Alternation was made to that structure to make it more realistic and safe. This alteration was needed in PhoneDialer too since you always need a bistro object to get the phone number correct. 