### PR TITLE
Removed font-family from styles in MenuSheet

### DIFF
--- a/components/MenuSheet.tsx
+++ b/components/MenuSheet.tsx
@@ -51,7 +51,6 @@ const styles = StyleSheet.create({
   },
   font: {
     color: "#000",
-    fontFamily: "Roboto",
   },
   bistro: {
     fontWeight: "bold",


### PR DESCRIPTION
close #60 

Not much to say about this. Removing the font "Roboto" from MenuSheet should take away errors while running app. 