### PR TITLE
header with go back is shown in MenuScreen

### DIFF
--- a/navigation/RootStackNavigator.tsx
+++ b/navigation/RootStackNavigator.tsx
@@ -4,6 +4,7 @@ import {
   NativeStackScreenProps,
 } from "@react-navigation/native-stack";
 import * as React from "react";
+import { useTheme } from "react-native-paper";
 import MenuScreen from "../screens/MenuScreen";
 import NotFoundScreen from "../screens/NotFoundScreen";
 import TabBistroMapNavigator, { TabParamList } from "./TabBistroMapNavigator";
@@ -47,18 +48,30 @@ export type RootStackScreenProps<
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function RootStackNavigator() {
+  const { colors } = useTheme();
+
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="Root" component={TabBistroMapNavigator} />
+    <Stack.Navigator
+      screenOptions={{
+        headerTintColor: colors.text,
+        headerTitleAlign: "center",
+        headerStyle: { backgroundColor: "#723A45" },
+      }}
+    >
+      <Stack.Screen
+        name="Root"
+        component={TabBistroMapNavigator}
+        options={{ headerShown: false }}
+      />
       <Stack.Screen
         name="Menu"
         component={MenuScreen}
-        options={({ route }) => ({ title: route.params.title })}
+        options={{ title: "Meny" }}
       />
       <Stack.Screen
         name="NotFound"
         component={NotFoundScreen}
-        options={{ title: "Oops!" }}
+        options={{ headerShown: false }}
       />
     </Stack.Navigator>
   );


### PR DESCRIPTION
close #62 

Header for MenuScreen is configured in RootStackNavigator. Using theme in the same way as in TabBistroMapNavigator. I tried to change the font size on the title to the same as the titles in the tabnavigator, but it just would not respond to the options (tried both in the stack navigator itself and in the stack screen). It is possible however to set the size on the titles in TabNavigator to bigger size. Is that something we might want to do, so they're all the same size?

According to the design all the header titles should be white. Maybe it will get set to white if we wrap the app in a PaperProvider, so it uses the right theme for light and dark mode from RN Paper? 

![header1](https://user-images.githubusercontent.com/71378960/136256164-c8c4fa48-54f6-47e9-9672-2e5b9587014e.png)


