### PR TITLE
changed background color and text color

### DIFF
--- a/screens/NotFoundScreen.tsx
+++ b/screens/NotFoundScreen.tsx
@@ -22,7 +22,7 @@ export default function NotFoundScreen({ navigation }: RootStackScreenProps<"Not
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#723A45",
+    backgroundColor: "#fff",
     alignItems: "center",
     justifyContent: "center",
     padding: 20,
@@ -31,7 +31,7 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontWeight: "bold",
     textAlign: "center",
-    color: "#fff",
+    color: "#723A45",
   },
   link: {
     marginTop: 15,
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
   },
   linkText: {
     fontSize: 14,
-    color: "#fff",
+    color: "#F8607E",
     textDecorationLine: "underline",
   },
 });


### PR DESCRIPTION
close #46 

Since we maybe will not have time to change the theme settings, I changed the background color to white and put our red and pink colors on the info text/go back - text. 

Now we do not have the problem with the extra white flashing frame in the background when switching from NotFoundScreen and the BistroScreen.

![notfound2](https://user-images.githubusercontent.com/71378960/136395398-10668a48-c38f-443d-8740-747f7e850366.png)


