### PR TITLE
switched to Expo Linking

### DIFF
--- a/components/PhoneDialer.tsx
+++ b/components/PhoneDialer.tsx
@@ -1,4 +1,5 @@
-import { Linking, Platform } from "react-native";
+import { Platform } from "react-native";
+import * as Linking from "expo-linking"
 import { BistroData } from "../data/bistroData";
 
 interface Props {


### PR DESCRIPTION
close #72 

Was using RN linking in PhoneDialer-component, but decided it is better to use Expo Linking (extension of RN Linking) instead.